### PR TITLE
fix: refactored ComposeTransform and configs

### DIFF
--- a/configs/experiment/examples/ag_news_classification.yaml
+++ b/configs/experiment/examples/ag_news_classification.yaml
@@ -5,7 +5,7 @@
 
 defaults:
   - /tasks: [classification, text]
-  - /transforms/models@model.forward_fn.transforms.net: hf
+  - /transforms/models@model.forward_fn.net: hf
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
 
@@ -30,16 +30,15 @@ params:
 
 model:
   forward_fn:
-    transforms:
-      net:
-        mapping:
-          input_ids: input_ids
-          attention_mask: attention_mask
-        model:
-          _target_: transformers.AutoModelForSequenceClassification.from_pretrained
-          _args_:
-            - ${params.data.model_name}
-          num_labels: ${params.data.num_classes}
+    net:
+      mapping:
+        input_ids: input_ids
+        attention_mask: attention_mask
+      model:
+        _target_: transformers.AutoModelForSequenceClassification.from_pretrained
+        _args_:
+          - ${params.data.model_name}
+        num_labels: ${params.data.num_classes}
 
 data:
   batch_size: 64

--- a/configs/experiment/examples/mnist_classification.yaml
+++ b/configs/experiment/examples/mnist_classification.yaml
@@ -5,7 +5,7 @@
 
 defaults:
   - /tasks: [classification, image]
-  - /transforms/models@model.forward_fn.transforms.net: torch
+  - /transforms/models@model.forward_fn.net: torch
 
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
@@ -24,18 +24,17 @@ params:
 
 model:
   forward_fn:
-    transforms:
-      net:
-        new_key: logits
-        mapping:
-          image: x
-        transform_fn:
-          _target_: src.models.components.simple_dense_net.SimpleDenseNet
-          input_size: 784
-          lin1_size: 128
-          lin2_size: 256
-          lin3_size: 64
-          output_size: ${params.data.num_classes}
+    net:
+      new_key: logits
+      mapping:
+        image: x
+      transform_fn:
+        _target_: src.models.components.simple_dense_net.SimpleDenseNet
+        input_size: 784
+        lin1_size: 128
+        lin2_size: 256
+        lin3_size: 64
+        output_size: ${params.data.num_classes}
 
 data:
   batch_size: 128

--- a/configs/tasks/classification.yaml
+++ b/configs/tasks/classification.yaml
@@ -2,7 +2,7 @@
 
 defaults:
   - _self_
-  - /transforms/base@model.forward_fn.transforms.argmax: argmax
+  - /transforms/base@model.forward_fn.argmax: argmax
   - /model/criterion: cross_entropy
   - /model/metrics: accuracy
 
@@ -10,9 +10,8 @@ model:
   forward_fn:
     _target_: src.transforms.base.TransformCompose
 
-    transforms:
-      net: ???
-      argmax: ???
+    net: ???
+    argmax: ???
 
   criterion_coefs:
     cross_entropy: 1.0

--- a/configs/tasks/image.yaml
+++ b/configs/tasks/image.yaml
@@ -2,15 +2,14 @@
 
 defaults:
   - _self_
-  - /transforms/image@data.transform.transforms.to_tensor: to_tensor
-  - /transforms/image@data.transform.transforms.normalize: normalize
+  - /transforms/image@data.transform.to_tensor: to_tensor
+  - /transforms/image@data.transform.normalize: normalize
 
 data:
   transform:
     _target_: src.transforms.base.TransformCompose
 
-    transforms:
-      to_tensor:
-        mapping:
-          image: pic
-        new_key: image
+    to_tensor:
+      mapping:
+        image: pic
+      new_key: image

--- a/src/transforms/base.py
+++ b/src/transforms/base.py
@@ -29,7 +29,7 @@ class TransformCompose(nn.Module):
     """
     def __init__(
         self,
-        transforms: Mapping[str, BaseTransform],
+        **transforms
     ):
         super().__init__()
         self.transforms = nn.ModuleList(transforms.values())


### PR DESCRIPTION
minor modification for more readable configs

removed `transforms` arg from `ComposeTransform` class and passing transforms as kwargs to avoid transforms key in yaml configs