### PR TITLE
Decomosing metrics from litmodule

### DIFF
--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -10,14 +10,14 @@ model_checkpoint:
   dirpath: ${paths.output_dir}/checkpoints
   filename: "epoch_{epoch:03d}"
   monitor: "val/best"
-  mode: "max"
+  mode: ${eval:"'max' if ${oc.select:callbacks.metrics_callback.tracked_metric_name,null} else 'min'"} # "max" if metric tracked, "min" for loss
   save_last: True
   auto_insert_metric_name: False
 
 early_stopping:
   monitor: "val/best"
   patience: 100
-  mode: "max"
+  mode: ${eval:"'max' if ${oc.select:callbacks.metrics_callback.tracked_metric_name,null} else 'min'"} # "max" if metric tracked, "min" for loss
 
 model_summary:
   max_depth: -1

--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -3,6 +3,7 @@ defaults:
   - early_stopping
   - model_summary
   - rich_progress_bar
+  - metrics_callback
   - _self_
 
 model_checkpoint:

--- a/configs/callbacks/metrics_callback.yaml
+++ b/configs/callbacks/metrics_callback.yaml
@@ -1,0 +1,7 @@
+# Metrics callback for computing and logging metrics during training/validation/testing
+
+metrics_callback:
+  _target_: ml_core.callbacks.MetricsCallback
+  metrics: null # metrics composition to track, should be specified in experiment config
+  tracked_metric_name: null # metric to track for best model selection, if null tracks validation loss
+

--- a/configs/callbacks/metrics_callback.yaml
+++ b/configs/callbacks/metrics_callback.yaml
@@ -4,4 +4,3 @@ metrics_callback:
   _target_: ml_core.callbacks.MetricsCallback
   metrics: null # metrics composition to track, should be specified in experiment config
   tracked_metric_name: null # metric to track for best model selection, if null tracks validation loss
-

--- a/configs/debug/default.yaml
+++ b/configs/debug/default.yaml
@@ -33,3 +33,4 @@ trainer:
 data:
   num_workers: 0 # debuggers don't like multiprocessing
   pin_memory: False # disable gpu memory pin
+  persistent_workers: False # disable persistent workers

--- a/configs/experiment/example.yaml
+++ b/configs/experiment/example.yaml
@@ -35,6 +35,21 @@ model:
 data:
   batch_size: 64
 
+callbacks:
+  metrics_callback:
+    tracked_metric_name: accuracy
+    metrics:
+      _target_: ml_core.models.utils.MetricsComposition
+      metrics:
+        accuracy:
+          _target_: torchmetrics.Accuracy
+          task: multiclass
+          num_classes: 10
+      mapping:
+        accuracy:
+          prediction: preds
+          label: target
+
 logger:
   wandb:
     tags: ${tags}

--- a/configs/model/mnist.yaml
+++ b/configs/model/mnist.yaml
@@ -36,20 +36,6 @@ criterions:
       output: input
       label: target
 
-metrics:
-  _target_: ml_core.models.utils.MetricsComposition
-  metrics:
-    accuracy:
-      _target_: torchmetrics.Accuracy
-      task: multiclass
-      num_classes: 10
-  mapping:
-    accuracy:
-      prediction: preds
-      label: target
-
-tracked_metric_name: accuracy
-
 optimizer:
   _target_: torch.optim.Adam
   _partial_: true

--- a/ml_core/__init__.py
+++ b/ml_core/__init__.py
@@ -1,1 +1,6 @@
 """Core ML package providing data modules, models, training and utilities."""
+
+from omegaconf import OmegaConf
+
+# Register eval resolver for conditional expressions in configs
+OmegaConf.register_new_resolver("eval", eval, replace=True)

--- a/ml_core/callbacks/__init__.py
+++ b/ml_core/callbacks/__init__.py
@@ -3,4 +3,3 @@
 from ml_core.callbacks.metrics_callback import MetricsCallback
 
 __all__ = ["MetricsCallback"]
-

--- a/ml_core/callbacks/__init__.py
+++ b/ml_core/callbacks/__init__.py
@@ -1,0 +1,6 @@
+"""Callbacks for PyTorch Lightning training."""
+
+from ml_core.callbacks.metrics_callback import MetricsCallback
+
+__all__ = ["MetricsCallback"]
+

--- a/ml_core/callbacks/metrics_callback.py
+++ b/ml_core/callbacks/metrics_callback.py
@@ -1,0 +1,178 @@
+from typing import Any, Literal
+
+from lightning import Callback, LightningModule, Trainer
+from torchmetrics import MaxMetric, MinMetric
+
+from ml_core.models.utils import MetricsComposition
+
+
+class MetricsCallback(Callback):
+    """Callback that manages metrics computation and logging for train/val/test stages.
+
+    This callback creates metric collections for each stage and attaches them to the
+    LightningModule, then updates and logs them during training. Metrics are kept as
+    module attributes to follow Lightning's expected pattern. Also tracks the best
+    validation metric for model selection.
+    """
+
+    def __init__(
+        self,
+        metrics: MetricsComposition | None = None,
+        tracked_metric_name: str | None = None,
+    ) -> None:
+        """Initialize the metrics callback.
+
+        :param metrics: Optional composition of metrics to track across stages.
+        :param tracked_metric_name: Metric key (without stage prefix) used to track the best
+            value on validation; if None, the total validation loss is tracked.
+        """
+        super().__init__()
+        self.metrics = metrics
+        self.tracked_metric_name = tracked_metric_name
+
+    def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
+        """Create and attach metric collections to the module before training starts.
+
+        :param trainer: The Lightning trainer.
+        :param pl_module: The Lightning module to attach metrics to.
+        :param stage: Current stage (fit, test, validate, predict).
+        """
+        # Set tracked_metric_name on the module so it can be used for scheduler config
+        if not hasattr(pl_module, "tracked_metric_name"):
+            pl_module.tracked_metric_name = self.tracked_metric_name
+
+        # Only create metrics once, and only if they don't already exist
+        if self.metrics is not None and not hasattr(pl_module, "train_metrics"):
+            pl_module.train_metrics = self.metrics.clone("train/")
+            pl_module.val_metrics = self.metrics.clone("val/")
+            pl_module.test_metrics = self.metrics.clone("test/")
+
+        # Create best validation metric tracker
+        if not hasattr(pl_module, "best_val_tracked_metric"):
+            pl_module.best_val_tracked_metric = (
+                MaxMetric() if self.tracked_metric_name else MinMetric()
+            )
+
+    def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Reset validation metrics and best metric tracker at the start of training.
+
+        :param trainer: The Lightning trainer.
+        :param pl_module: The Lightning module.
+        """
+        if hasattr(pl_module, "val_metrics"):
+            for metric_name in pl_module.val_metrics:
+                pl_module.val_metrics[metric_name].reset()
+
+        if hasattr(pl_module, "best_val_tracked_metric"):
+            pl_module.best_val_tracked_metric.reset()
+
+    def _on_stage_batch_end(
+        self,
+        stage: Literal["train", "val", "test"],
+        pl_module: LightningModule,
+        outputs: dict[str, Any],
+    ) -> None:
+        """Update and log metrics for a given stage after each batch.
+
+        :param stage: Current stage (train, val, or test).
+        :param pl_module: The Lightning module.
+        :param outputs: Outputs from the step (includes the augmented batch).
+        """
+        metrics_attr = f"{stage}_metrics"
+        if hasattr(pl_module, metrics_attr):
+            metrics = getattr(pl_module, metrics_attr)
+            metrics(outputs)
+            for metric_name in metrics.keys():
+                pl_module.log(
+                    f"{metric_name}",
+                    metrics[metric_name],
+                    on_step=False,
+                    on_epoch=True,
+                    prog_bar=True,
+                    sync_dist=True,
+                )
+
+    def on_train_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: dict[str, Any],
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        """Update and log training metrics after each batch.
+
+        :param trainer: The Lightning trainer.
+        :param pl_module: The Lightning module.
+        :param outputs: Outputs from the training step (includes the augmented batch).
+        :param batch: The current batch.
+        :param batch_idx: Index of the current batch.
+        """
+        self._on_stage_batch_end("train", pl_module, outputs)
+
+    def on_validation_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: dict[str, Any],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Update and log validation metrics after each batch.
+
+        :param trainer: The Lightning trainer.
+        :param pl_module: The Lightning module.
+        :param outputs: Outputs from the validation step (includes the augmented batch).
+        :param batch: The current batch.
+        :param batch_idx: Index of the current batch.
+        :param dataloader_idx: Index of the current dataloader.
+        """
+        self._on_stage_batch_end("val", pl_module, outputs)
+
+    def on_test_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: dict[str, Any],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Update and log test metrics after each batch.
+
+        :param trainer: The Lightning trainer.
+        :param pl_module: The Lightning module.
+        :param outputs: Outputs from the test step (includes the augmented batch).
+        :param batch: The current batch.
+        :param batch_idx: Index of the current batch.
+        :param dataloader_idx: Index of the current dataloader.
+        """
+        self._on_stage_batch_end("test", pl_module, outputs)
+
+    def on_validation_epoch_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Compute and log best validation metric at epoch end.
+
+        :param trainer: The Lightning trainer.
+        :param pl_module: The Lightning module.
+        """
+        if self.tracked_metric_name is None:
+            tracked_metric = pl_module.val_losses["total"]
+        else:
+            if not hasattr(pl_module, "val_metrics"):
+                raise ValueError(
+                    f"tracked_metric_name '{self.tracked_metric_name}' is set but "
+                    "val_metrics not found. Did you set metrics in MetricsCallback?"
+                )
+            tracked_metric = pl_module.val_metrics[self.tracked_metric_name]
+
+        pl_module.best_val_tracked_metric(tracked_metric.compute())
+        pl_module.log(
+            "val/best",
+            pl_module.best_val_tracked_metric.compute(),
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            sync_dist=True,
+        )
+

--- a/ml_core/callbacks/metrics_callback.py
+++ b/ml_core/callbacks/metrics_callback.py
@@ -10,9 +10,9 @@ class MetricsCallback(Callback):
     """Callback that manages metrics computation and logging for train/val/test stages.
 
     This callback creates metric collections for each stage and attaches them to the
-    LightningModule, then updates and logs them during training. Metrics are kept as
-    module attributes to follow Lightning's expected pattern. Also tracks the best
-    validation metric for model selection.
+    LightningModule, then updates and logs them during training. Metrics are kept as module
+    attributes to follow Lightning's expected pattern. Also tracks the best validation metric for
+    model selection.
     """
 
     def __init__(
@@ -23,8 +23,8 @@ class MetricsCallback(Callback):
         """Initialize the metrics callback.
 
         :param metrics: Optional composition of metrics to track across stages.
-        :param tracked_metric_name: Metric key (without stage prefix) used to track the best
-            value on validation; if None, the total validation loss is tracked.
+        :param tracked_metric_name: Metric key (without stage prefix) used to track the best value
+            on validation; if None, the total validation loss is tracked.
         """
         super().__init__()
         self.metrics = metrics
@@ -175,4 +175,3 @@ class MetricsCallback(Callback):
             prog_bar=True,
             sync_dist=True,
         )
-

--- a/ml_core/models/base_module.py
+++ b/ml_core/models/base_module.py
@@ -2,17 +2,17 @@ from typing import Any, Callable, Literal, Mapping
 
 import torch
 from lightning import LightningModule
-from torchmetrics import MaxMetric, MeanMetric, MetricCollection, MinMetric
+from torchmetrics import MeanMetric, MetricCollection
 
-from ml_core.models.utils import CriterionsComposition, MetricsComposition
+from ml_core.models.utils import CriterionsComposition
 
 
 class BaseLitModule(LightningModule):
-    """Generic LightningModule wiring forward, losses, metrics, and optimizers.
+    """Generic LightningModule wiring forward, losses, and optimizers.
 
     Expects a callable `forward_fn`, a `CriterionsComposition` for computing losses,
-    optional `MetricsComposition`, and optimizer/scheduler factories. Provides common
-    training/validation/test steps and logs with `sync_dist` enabled for DDP.
+    and optimizer/scheduler factories. Provides common training/validation/test steps
+    and logs with `sync_dist` enabled for DDP. Metrics are handled via MetricsCallback.
     """
 
     def __init__(
@@ -23,8 +23,6 @@ class BaseLitModule(LightningModule):
         scheduler: (
             Callable[[torch.optim.Optimizer], torch.optim.lr_scheduler.LRScheduler] | None
         ) = None,
-        metrics: MetricsComposition | None = None,
-        tracked_metric_name: str | None = None,
         compile: bool = False,
     ) -> None:
         """Initialize the Lightning module wiring.
@@ -33,9 +31,6 @@ class BaseLitModule(LightningModule):
         :param criterions: Composition of losses operating on the output batch mapping.
         :param optimizer: Factory returning a configured optimizer for the model parameters.
         :param scheduler: Optional factory returning an LR scheduler for the optimizer.
-        :param metrics: Optional composition of metrics operating on the output batch mapping.
-        :param tracked_metric_name: Metric key (without stage prefix) used to track the best
-            value on validation; if None, the total validation loss is tracked.
         :param compile: Whether to compile ``forward_fn`` with ``torch.compile`` during fit.
         """
         super().__init__()
@@ -45,24 +40,12 @@ class BaseLitModule(LightningModule):
         self.forward_fn = forward_fn
         self.criterions = criterions
 
-        if metrics is not None:
-            self.train_metrics = metrics.clone("train/")
-            self.val_metrics = metrics.clone("val/")
-            self.test_metrics = metrics.clone("test/")
-
         self.train_losses = MetricCollection(
             {criterion_name: MeanMetric() for criterion_name in self.criterions.keys()}
             | {"total": MeanMetric()}
         ).clone("train/")
         self.val_losses = self.train_losses.clone("val/")
         self.test_losses = self.train_losses.clone("test/")
-
-        self.best_val_tracked_metric = (
-            MaxMetric() if metrics and tracked_metric_name else MinMetric()
-        )
-
-        if tracked_metric_name is not None and metrics is None:
-            raise ValueError("`tracked_metric_name` should be None in case null metrics")
 
     def forward(self, batch) -> Mapping[str, Any]:
         """Forward pass producing a dict-like output expected by losses/metrics.
@@ -73,20 +56,15 @@ class BaseLitModule(LightningModule):
         return self.forward_fn(batch)
 
     def on_train_start(self) -> None:
-        """Reset validation aggregators and best metric at train start."""
+        """Reset validation loss aggregators at train start."""
         for criterion_name in self.criterions.keys():
             self.val_losses[criterion_name].reset()
         self.val_losses["total"].reset()
 
-        if hasattr(self, "val_metrics"):
-            for metric_name in self.val_metrics:
-                self.val_metrics[metric_name].reset()
-        self.best_val_tracked_metric.reset()
-
     def model_step(
         self, batch: Mapping[str, Any], stage: Literal["train", "val", "test"]
     ) -> Mapping[str, Any]:
-        """Shared step computing losses/metrics and logging for a stage."""
+        """Shared step computing losses and logging for a stage."""
         batch = self(batch)
 
         # Losses
@@ -103,20 +81,6 @@ class BaseLitModule(LightningModule):
                 sync_dist=True,
             )
 
-        # Metrics
-        if hasattr(self, f"{stage}_metrics"):
-            metrics = getattr(self, f"{stage}_metrics")
-            metrics(batch)
-            for metric_name in metrics.keys():
-                self.log(
-                    f"{metric_name}",
-                    metrics[metric_name],
-                    on_step=False,
-                    on_epoch=True,
-                    prog_bar=True,
-                    sync_dist=True,
-                )
-
         return {"loss": losses["total"], **batch}
 
     def training_step(self, batch: Mapping[str, Any], batch_idx: int) -> torch.Tensor:
@@ -131,23 +95,6 @@ class BaseLitModule(LightningModule):
         """Lightning test step."""
         return self.model_step(batch, "test")
 
-    def on_validation_epoch_end(self) -> None:
-        """Compute and log best validation metric at epoch end."""
-        if self.hparams.tracked_metric_name is None:
-            tracked_metric = self.val_losses["total"]
-        else:
-            tracked_metric = self.val_metrics[self.hparams.tracked_metric_name]
-
-        self.best_val_tracked_metric(tracked_metric.compute())
-        self.log(
-            "val/best",
-            self.best_val_tracked_metric.compute(),
-            on_step=False,
-            on_epoch=True,
-            prog_bar=True,
-            sync_dist=True,
-        )
-
     def setup(self, stage: str) -> None:
         """Optionally compile the wrapped forward callable in fit stage."""
         if self.hparams.compile and stage == "fit":
@@ -158,11 +105,13 @@ class BaseLitModule(LightningModule):
         optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())
         if self.hparams.scheduler is not None:
             scheduler = self.hparams.scheduler(optimizer=optimizer)
+            # tracked_metric_name is set by MetricsCallback in setup
+            tracked_metric_name = getattr(self, "tracked_metric_name", None)
             return {
                 "optimizer": optimizer,
                 "lr_scheduler": {
                     "scheduler": scheduler,
-                    "monitor": f"val/{self.hparams.tracked_metric_name or 'loss'}",
+                    "monitor": f"val/{tracked_metric_name or 'total'}",
                     "interval": "epoch",
                     "frequency": 1,
                 },


### PR DESCRIPTION
# Refactor: Extract Metrics Logic from BaseLitModule to MetricsCallback

## Summary

This PR refactors the metrics handling in the Lightning-Hydra template by extracting all metrics-related logic from `BaseLitModule` into a dedicated `MetricsCallback`. This improves separation of concerns and makes metrics configuration more flexible and experiment-centric.

## Motivation

- **Better Separation of Concerns**: Model architecture should be separate from what metrics we use to evaluate it
- **More Flexible Configuration**: Different experiments can track different metrics without modifying model configs
- **Cleaner Code**: `BaseLitModule` now focuses purely on model training (forward pass, losses, optimization)
- **Follows Best Practices**: Uses Lightning's callback system for cross-cutting concerns like metrics

## Key Changes

### 1. Created `MetricsCallback` (`ml_core/callbacks/metrics_callback.py`)

A new PyTorch Lightning callback that:
- Takes `metrics` and `tracked_metric_name` as parameters
- Creates and attaches metric collections to the Lightning module in `setup()`
- Updates and logs metrics in `on_*_batch_end()` hooks
- Tracks best validation metric in `on_validation_epoch_end()`
- Uses a common `_on_stage_batch_end()` method to avoid code duplication

**Key Features:**
- Metrics remain as module attributes (following Lightning's pattern)
- Handles metric reset at training start
- Supports tracking metrics or validation loss for best model selection
- Works seamlessly with distributed training (sync_dist=True)

### 2. Updated `BaseLitModule` (`ml_core/models/base_module.py`)

**Removed:**
- `metrics` parameter from `__init__`
- `tracked_metric_name` parameter from `__init__`
- Metrics creation and initialization
- Metrics computation and logging from `model_step()`
- `on_validation_epoch_end()` method
- Best metric tracker creation and reset

**Simplified:**
- Now focuses on forward pass, losses, and optimization
- Cleaner, more focused interface
- Reduced imports (removed `MaxMetric`, `MinMetric`, `MetricsComposition`)

### 3. Configuration Changes

**Model Config (`configs/model/mnist.yaml`):**
- Removed `metrics` configuration
- Removed `tracked_metric_name` configuration
- Now purely defines model architecture, losses, and optimization

**Experiment Config (`configs/experiment/example.yaml`):**
- Added `callbacks.metrics_callback.tracked_metric_name`
- Added `callbacks.metrics_callback.metrics` configuration
- Metrics are now defined at the experiment level

**New Callback Config (`configs/callbacks/metrics_callback.yaml`):**
- Created default metrics callback configuration
- Included in `configs/callbacks/default.yaml`

### 4. Documentation Updates (`docs/ARCHITECTURE.md`)

- Added comprehensive `MetricsCallback` documentation section
- Updated `BaseLitModule` section to reflect simplified interface
- Updated MNIST example workflow to show metrics in experiment config
- Updated all code examples throughout the document
- Added notes explaining the new architecture
- Updated "Conducting New Experiments" section
- Added "Separation of Concerns" to architecture summary

## Before / After

### Before: Metrics in Model Config
```yaml
# configs/model/mnist.yaml
_target_: ml_core.models.base_module.BaseLitModule

# ... model definition ...

metrics:
  _target_: ml_core.models.utils.MetricsComposition
  metrics:
    accuracy:
      _target_: torchmetrics.Accuracy
      task: multiclass
      num_classes: 10
  mapping:
    accuracy:
      prediction: preds
      label: target

tracked_metric_name: accuracy
```

### After: Metrics in Experiment Config
```yaml
# configs/model/mnist.yaml
_target_: ml_core.models.base_module.BaseLitModule

# ... model definition (no metrics) ...

# ---

# configs/experiment/example.yaml
callbacks:
  metrics_callback:
    tracked_metric_name: accuracy
    metrics:
      _target_: ml_core.models.utils.MetricsComposition
      metrics:
        accuracy:
          _target_: torchmetrics.Accuracy
          task: multiclass
          num_classes: 10
      mapping:
        accuracy:
          prediction: preds
          label: target
```

## Benefits

1. **Reusability**: Same model architecture can be evaluated with different metrics across experiments
2. **Clarity**: Clear separation between "what the model does" (architecture) and "how we measure it" (metrics)
3. **Flexibility**: Easy to add/remove/change metrics per experiment without touching model code
4. **Maintainability**: Smaller, more focused components are easier to understand and maintain

## Breaking Changes

⚠️ **Breaking Change**: Existing model configs that define `metrics` or `tracked_metric_name` will need to be updated:

**Migration Guide:**
1. Remove `metrics` and `tracked_metric_name` from your model configs
2. Add them to your experiment configs under `callbacks.metrics_callback`
3. Ensure `metrics_callback` is included in your callbacks config (default in `configs/callbacks/default.yaml`)

## Testing

✅ All existing tests pass:
- `pytest tests/test_sweeps.py::test_experiments` - PASSED (11.15s)
- No linter errors

The refactoring maintains 100% functional compatibility while improving code structure.

## Files Changed

**New Files:**
- `ml_core/callbacks/metrics_callback.py` - MetricsCallback implementation
- `ml_core/callbacks/__init__.py` - Callback exports
- `configs/callbacks/metrics_callback.yaml` - Callback configuration

**Modified Files:**
- `ml_core/models/base_module.py` - Removed metrics logic
- `configs/model/mnist.yaml` - Removed metrics configuration
- `configs/experiment/example.yaml` - Added metrics configuration
- `configs/callbacks/default.yaml` - Added metrics_callback
- `docs/ARCHITECTURE.md` - Comprehensive documentation updates

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass
- [x] No linter errors
- [x] Documentation updated
- [x] Breaking changes documented with migration guide
- [x] Backward compatibility considerations addressed
